### PR TITLE
BUGFIX | Add license boilerplate for dwz_test.go

### DIFF
--- a/dwz_test.go
+++ b/dwz_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Matthias Vedder
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package dwz
 
 import (


### PR DESCRIPTION
previously forgotten